### PR TITLE
Algunas reglas de eslint y mejor interacción con prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,14 @@ module.exports = {
   root: true,
   extends: '@react-native-community',
   rules: {
-    semi: [0, 'never', { beforeStatementContinuationChars: 'always' }],
-    'comma-dangle': [0, 'never']
+    // Desactivar las reglas de prettier porque de todas maneras lo estamos
+    // usando antes.
+    'prettier/prettier': 0,
+    // Nunca usar ; al final de las líneas.
+    'semi': [1, 'never', { beforeStatementContinuationChars: 'always' }],
+    // Nunca dejar una , al final de los items en arrays y objetos.
+    'comma-dangle': [1, 'never'],
+    // Forzar a que haya espacios entre { } incluso en jsx.
+    'react/jsx-curly-spacing': [1, { when: 'always', children: { when: 'always' } }]
   }
 }


### PR DESCRIPTION
Tuve que desactivar la regla de eslint que reutiliza las reglas de prettier para poder contradecir algunas cosas y que eslint las corrija con `--fix`, como los espacios dentro de las llaves (`{ a: 1 }` y no `{a: 1}`), pero no debería ser un problema porque de todas maneras vamos a pasar prettier antes. Ahora podemos agregar otras reglas que nos gusten y que eslint puede corregir.